### PR TITLE
Fix broken URL path in generateUrl()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,10 +51,9 @@ export const generateUrl = (
     options: UrlOptions,
     config: ValidTotpConfig
 ): string => {
-    const url = new URL(`otpauth://totp`);
-    url.pathname = `/${encodeURIComponent(options.issuer)}:${encodeURIComponent(
+    const url = new URL(`otpauth://totp/${encodeURIComponent(options.issuer)}:${encodeURIComponent(
         options.user
-    )}`;
+    )}`);
 
     const params = new URLSearchParams({
         issuer: options.issuer,


### PR DESCRIPTION
This pull request is to fix broken/missing issuer and user values that weren't getting added to the returned URL from the `generateUrl()` function.

After some digging, it appears that `otpauth://totp` is not read as a valid URL, as seen below. `//totp` is getting read as the pathname, instead of being included in the protocol, in which case seems to cause the URL() constructor to ignore attempts to set a new pathname on the URL.

![image](https://github.com/PlanetHoster/time2fa/assets/65981261/1f0a1928-8401-4c97-a09d-3d8d509bead5)

To circumvent this, the pathname value, which includes the issuer and user values has been moved into the URL constructor, which now allows `generateUrl()` to return the proper, full `otpauth://` URL value.

Before: `otpauth://totp/?issuer=Issuer&period=30&secret=value`

After: `otpauth://totp/Issuer:fake@email.com?issuer=Issuer&period=30&secret=value`


