### PR TITLE
Fix types export when imported from a recent CJS system

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,14 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs"
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
     }
   },
   "main": "./dist/index.mjs",


### PR DESCRIPTION
Currently it fails when importing from a commonjs typescript project with `module: "NodeNext"` and `moduleResolution: "nodenext"` in the `tsconfig.json` file.

See https://arethetypeswrong.github.io/?p=time2fa%401.4.0

Explanations: https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseESM.md

Alternative fix is to remove the `"types"` field in the `"."` export, it should work too. (as explained in the link above)